### PR TITLE
ci: switch npm publish to OIDC Trusted Publishing

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -3,28 +3,29 @@ name: publish
 on:
   release:
     types: [released]
-  
+  workflow_dispatch:
+
 jobs:
   publish:
     runs-on: ubuntu-latest
     permissions:
-      packages: write
       contents: read
+      id-token: write
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
         with:
           ref: main
       - uses: actions/setup-node@v4
         with:
-          node-version: '20.x'
+          node-version: '22.x'
           registry-url: 'https://registry.npmjs.org'
       - uses: actions/cache@v4
         with:
           path: node_modules
           key: ${{ runner.os }}-node-${{ github.event_name }}-${{ hashFiles('**/package-lock.json') }}
           restore-keys: ${{ runner.os }}-node-${{ github.event_name }}-
-      - run: npm i
+      # Trusted Publishing (OIDC) requires npm >= 11.5.1
+      - run: npm install -g npm@latest
+      - run: npm ci
       - run: npm run build
       - run: npm publish --access=public
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
## 概要
npm publish の認証を `NPM_TOKEN` から **Trusted Publishing (OIDC)** に切り替えます。トークン期限切れや 2FA/OTP（EOTP）による CI 失敗を根本的に解消します。

## 変更点
- `permissions` に `id-token: write` を追加（未使用の `packages: write` は削除）
- publish ステップから `NODE_AUTH_TOKEN` を撤去（トークン不要）
- npm を最新化（Trusted Publishing は npm >= 11.5.1 が必要）
- Node 22.x / `actions/checkout@v4` / `npm ci` に更新
- `workflow_dispatch` を追加（手動実行可能に）

## マージ前の前提
npm 側で `convert-cases` の **Trusted Publisher**（GitHub Actions: `akoarum/convert-cases`, workflow `publish.yml`）を登録済みであること。

## マージ後
`v2.0.4` のリリースを作り直して publish ワークフローを再実行します。

🤖 Generated with [Claude Code](https://claude.com/claude-code)